### PR TITLE
add Kuudra + Dungeon items that replace the SB Menu to banned items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -97,6 +97,9 @@ object ItemPickupLog {
         "SKYBLOCK_MENU",
         "CANCEL_PARKOUR_ITEM",
         "CANCEL_RACE_ITEM",
+        "MAXOR_ENERGY_CRYSTAL",
+        "ELLE_SUPPLIES",
+        "ELLE_FUEL_CELL",
     )
     private val bannedItemsConverted = bannedItemsPattern.map { it.toString().asInternalName() }
 


### PR DESCRIPTION


## What
Adds Elle supplies + fuel cells + Crystals that replace the SB Menu to the banned item list
(Sorry Seraid you hadn't made a PR for this in the last 3h so...)

## Changelog Improvements
+ Stopped SB Menu replacing items from dungeons + kuudra being put in the pickup log- Fazfoxy

